### PR TITLE
Fix build error for arduino_hw_interface

### DIFF
--- a/arduino_hw_interface/CMakeLists.txt
+++ b/arduino_hw_interface/CMakeLists.txt
@@ -16,6 +16,8 @@ add_library(arduino_hw_interface SHARED
   src/arduino_hw_interface.cpp
 )
 
+target_include_directories(arduino_hw_interface PUBLIC include)
+
 ament_target_dependencies(arduino_hw_interface
   rclcpp
   hardware_interface


### PR DESCRIPTION
The previous build failed because the compiler could not find arduino_hw_interface.hpp.

This commit explicitly adds the 'include' directory to the target's include paths in `arduino_hw_interface/CMakeLists.txt` by adding the line `target_include_directories(arduino_hw_interface PUBLIC include)`.

This should resolve the header not found issue.